### PR TITLE
Install and run RethinkDB as a CircleCI build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Do Make Rethink
 
+[![Circle CI](https://circleci.com/gh/FundingCircle/do-make-rethink.svg?style=svg)](https://circleci.com/gh/FundingCircle/do-make-rethink)
+
 A Clojure library for making RethinkDB databases.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Circle CI](https://circleci.com/gh/FundingCircle/do-make-rethink.svg?style=svg)](https://circleci.com/gh/FundingCircle/do-make-rethink)
 
-A Clojure library for making RethinkDB databases.
+A Clojure library for making [RethinkDB](https://rethinkdb.com/) databases.
 
 ## Usage
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+dependencies:
+  pre:
+    - 'source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list'
+    - 'wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -'
+    - sudo apt-get update
+    - sudo apt-get install rethinkdb
+    - sudo cp /etc/rethinkdb/default.conf.sample /etc/rethinkdb/instances.d/test.conf
+  post:
+    - sudo service rethinkdb start


### PR DESCRIPTION
:information_desk_person: The tests depend on a running instance of RethinkDB being available. This CircleCI configuration file does that prior to the tests being run.